### PR TITLE
Remove the need for CORS in development

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,8 +2,9 @@
   "name": "lookup-client",
   "version": "0.0.1",
   "private": true,
+  "proxy": "http://localhost:3001/",
   "devDependencies": {
-    "react-scripts": "0.2.1"
+    "react-scripts": "0.2.3"
   },
   "dependencies": {
     "react": "^15.2.1",

--- a/client/src/Client.js
+++ b/client/src/Client.js
@@ -1,6 +1,6 @@
 
 function search(query) {
-  return fetch(`http://localhost:3001/api/food?q=${query}`, {
+  return fetch(`/api/food?q=${query}`, {
     accept: 'application/json',
   }).then(checkStatus)
     .then(parseJSON);

--- a/server.js
+++ b/server.js
@@ -10,16 +10,6 @@ const app = express();
 
 app.set('port', (process.env.API_PORT || 3001));
 
-// Allow requests from pages served by Webpack
-const allowCrossDomain = function (req, res, next) {
-  res.header('Access-Control-Allow-Origin', 'http://localhost:3000');
-  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
-
-  next();
-};
-app.use(allowCrossDomain);
-
 const COLUMNS = [
   'sugar_g',
   'carbohydrate_g',


### PR DESCRIPTION
You can drop the code for CORS now that `react-scripts@0.2.3` is released!
