### PR TITLE
Remove ./node_modues/.bin/ from the npm run server

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "scripts": {
     "start": "nf start -p $PORT",
     "dev": "nf start -p 3000 --procfile Procfile.dev",
-    "server": "./node_modules/.bin/babel-node server.js"
+    "server": "babel-node server.js"
   }
 }


### PR DESCRIPTION
First of all, thank you so much for your awesome tutorial!

This PR removes `./node_modues/.bin/` from the `npm run server`

**From npm documentation:**

> In addition to the shell's pre-existing PATH, npm run adds node_modules/.bin to the PATH provided to scripts. Any binaries provided by locally-installed dependencies can be used without the node_modules/.bin prefix.
https://docs.npmjs.com/cli/run-script